### PR TITLE
Correct Horde\Socket\Client connect retry argument ordering

### DIFF
--- a/lib/Horde/Socket/Client.php
+++ b/lib/Horde/Socket/Client.php
@@ -301,7 +301,7 @@ class Client
              * these are likely transient issues. Retry up to 3 times in these
              * instances. */
             if (!$error_number && ($retries < 3)) {
-                return $this->_connect($host, $port, $timeout, $secure, ++$retries, $context);
+                return $this->_connect($host, $port, $timeout, $secure, $context, ++$retries);
             }
 
             $e = new Client\Exception(


### PR DESCRIPTION
Retry doesn't correctly pass context and retry count to next connect attempts.