### PR TITLE
Remove insecure by default option

### DIFF
--- a/lib/Horde/Socket/Client.php
+++ b/lib/Horde/Socket/Client.php
@@ -91,16 +91,6 @@ class Client
             $secure = false;
         }
 
-        $context = array_merge_recursive(
-            array(
-                'ssl' => array(
-                    'verify_peer' => false,
-                    'verify_peer_name' => false
-                )
-            ),
-            $context
-        );
-
         $this->_params = $params;
 
         $this->_connect($host, $port, $timeout, $secure, $context);


### PR DESCRIPTION
There are two issues with the code deleted in this PR:
* array_merge_recursive converts verify_peer/verify_peer_name to an array when you set it via context. Therefore, it is not possible to set the settings to true. See https://www.php.net/manual/en/function.array-merge-recursive.php
* the setting is insecure by default. Better make it secure by default and let the user decide if invalid certificates should be accepted.

This PR will make the connection secure by default. The setting can still be changed by setting verify_peer to false via $context.
