### PR TITLE
Fix SSL socket options overrides

### DIFF
--- a/lib/Horde/Socket/Client.php
+++ b/lib/Horde/Socket/Client.php
@@ -91,7 +91,7 @@ class Client
             $secure = false;
         }
 
-        $context = array_merge_recursive(
+        $context = array_replace_recursive(
             array(
                 'ssl' => array(
                     'verify_peer' => false,


### PR DESCRIPTION
Php's `array_merge_recursive` can't be used for custom SSL options as it
combines duplicate key values into an array. Hence a passed context of

```php
[
  'ssl' => [
    'verify_peer' => true,
    'verify_peer_name' => true,
]
```

resulted in

```php
[
  'ssl' => [
    'verify_peer' => [true, false],
    'verify_peer_name' => [true, false],
]
```

`array_replace_recursive` does the expected replacement.

Proof: https://3v4l.org/bNfs2

This is neccessary to do peer verification with the Horde libs, as
discussed at https://bugs.horde.org/ticket/13730

Please verify and review @mrubinsk @yunosh 